### PR TITLE
Camera: default to widest field of view (sensor-native 4:3)

### DIFF
--- a/Sources/QuickPoseCamera/QuickPoseCamera.swift
+++ b/Sources/QuickPoseCamera/QuickPoseCamera.swift
@@ -96,7 +96,7 @@ public class QuickPoseCamera {
             session.addInput(input)
             session.addOutput(output)
             initialFrameRate = device.activeVideoMaxFrameDuration.timescale
-            device.setFrameRate(frameRate)
+            device.selectFormat(frameRate: frameRate ?? Double(initialFrameRate)) // only the field of view should change: without a requested frame rate, keep the device's default
             
             if session.connections[0].isVideoOrientationSupported, let videoOrientation = AVCaptureVideoOrientation(rawValue: UIDevice.current.orientation.rawValue) {
                 
@@ -141,30 +141,31 @@ public class QuickPoseCamera {
     public func setFrameRate(_ frameRate: Double?) {
         qpProcessingQueue.async {
             self.session?.stopRunning()
-            self.device?.setFrameRate(frameRate == nil ? Double(self.initialFrameRate) : frameRate)
+            self.device?.selectFormat(frameRate: frameRate ?? Double(self.initialFrameRate))
             self.session?.startRunning()
         }
     }
 }
 
 extension AVCaptureDevice {
-    fileprivate func setFrameRate(_ frameRate: Double?) {
-        
-        guard let frameRate = frameRate else { return } // if possible avoid changing
+    /// Single format policy: the widest field of view the lens offers, at the smallest
+    /// resolution with a short side of at least 1080 (larger buffers only slow inference),
+    /// running at the requested frame rate. 16:9 video formats are a centre crop of the
+    /// sensor, so this typically selects a sensor-native 4:3 format.
+    fileprivate func selectFormat(frameRate: Double) {
         var selectedFormat: AVCaptureDevice.Format? = nil
-        let activeDimensions = CMVideoFormatDescriptionGetDimensions(activeFormat.formatDescription);
         for format in formats {
-            guard selectedFormat == nil else { break }
-            for range in format.videoSupportedFrameRateRanges {
-                let dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
-                //print(dimensions, range.maxFrameRate)
-                if (range.minFrameRate <= frameRate && frameRate <= range.maxFrameRate && dimensions.width == activeDimensions.width && dimensions.height == activeDimensions.height) {
-                    selectedFormat = format
-                    break
-                }
+            let dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription)
+            if dimensions.height < 1080 { continue }
+            if !format.videoSupportedFrameRateRanges.contains(where: { $0.minFrameRate <= frameRate && frameRate <= $0.maxFrameRate }) { continue }
+            if let best = selectedFormat {
+                let bestDimensions = CMVideoFormatDescriptionGetDimensions(best.formatDescription)
+                if format.videoFieldOfView < best.videoFieldOfView { continue }
+                if format.videoFieldOfView == best.videoFieldOfView && dimensions.width * dimensions.height >= bestDimensions.width * bestDimensions.height { continue }
             }
+            selectedFormat = format
         }
-        
+
         if let selectedFormat = selectedFormat {
             do {
                 try lockForConfiguration()
@@ -172,11 +173,14 @@ extension AVCaptureDevice {
                 activeVideoMinFrameDuration = CMTimeMake(value: 1, timescale: Int32(frameRate))
                 activeVideoMaxFrameDuration = CMTimeMake(value: 1, timescale: Int32(frameRate))
                 unlockForConfiguration()
+                let dimensions = CMVideoFormatDescriptionGetDimensions(selectedFormat.formatDescription)
+                print("QuickPose camera format \(dimensions.width)x\(dimensions.height), fov \(selectedFormat.videoFieldOfView), \(Int(frameRate))fps")
             } catch {
                 print("LockForConfiguration failed with error: \(error.localizedDescription)")
             }
         } else {
-            print("QuickPose couldn't set frameRate to \(frameRate)fps at \(activeDimensions), continuing with \(String(format:"%d",activeVideoMaxFrameDuration.timescale))fps")
+            let activeDimensions = CMVideoFormatDescriptionGetDimensions(activeFormat.formatDescription)
+            print("QuickPose couldn't select a format for \(frameRate)fps, continuing with \(activeDimensions.width)x\(activeDimensions.height) at \(String(format:"%d",activeVideoMaxFrameDuration.timescale))fps")
         }
     }
 }


### PR DESCRIPTION
## Summary
- `QuickPoseCamera` now selects the camera format with the widest field of view the lens offers (smallest resolution with a short side >= 1080), instead of the session default — a 16:9 centre crop of the sensor. Typically 1440x1080 4:3 instead of 1920x1080.
- One format policy shared by `start()` and `setFrameRate`: widest FOV, constrained to the requested frame rate; logs and keeps the current format if constraints can't be met.
- Frame rate is pinned to the device's previous default when none is requested, so only the field of view changes (setting `activeFormat` would otherwise reset frame durations).

## Behaviour change
Apps update from a cropped 16:9 view to the sensor's full field of view (~14° wider on front cameras — the stock Camera app's "zoomed out" selfie framing). Capture aspect changes 16:9 → 4:3.

## Testing
- A/B verified on iPhone 14 Pro (front camera): full-body framing at close range where the old build only fit a face; fps unchanged at 30.
- Compile-verified via BasicDemo (public package configuration) and typecheck against iOS 14 SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)